### PR TITLE
Include "plugins" option to allow users to extend functionality from lovelace

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -91,6 +91,7 @@ class ChartjsCard extends LitElement {
     this._updateFromEntities = [];
     this.chartProp.data = this._evaluateConfig(deepcopy(this._config.data));
     this.chartProp.options = this._evaluateConfig(deepcopy(this._config.options));
+    this.chartProp.plugins = this._evaluateConfig(deepcopy(this._config.plugins));
     this.chart.update({duration: 0, easing: 'linear'});
   }
   
@@ -105,6 +106,7 @@ class ChartjsCard extends LitElement {
     chartconfig.type = this._config.chart;
     chartconfig.data = this._evaluateConfig(deepcopy(this._config.data));
     chartconfig.options = this._evaluateConfig(deepcopy(this._config.options));
+    chartconfig.plugins = this._evaluateConfig(deepcopy(this._config.plugins));
     
     if (typeof this._config.custom_options === "object") {
       if (typeof this._config.custom_options.showLegend === "boolean") {


### PR DESCRIPTION
This update allows a new tag "plugins:" at the root of the card config which allows for the definition of custom plugins to the card.

For example the following draws a dashed vertical line in line with the mouse hover position (requires tooltips intersect option to be false)

``` 
       plugins:
          - afterDatasetsDraw:  '${(function chart(chart) { if (chart.tooltip._active && chart.tooltip._active.length) {
                                  var activePoint = chart.tooltip._active[0],
                                  ctx = chart.ctx,
                                  y_axis = chart.scales["y-axis-0"],
                                  x = activePoint.tooltipPosition().x,
                                  topY = y_axis.top,
                                  bottomY = y_axis.bottom;
                                 ctx.save();
                                 ctx.beginPath();
                                 ctx.moveTo(x, topY);
                                 ctx.lineTo(x, bottomY);
                                 ctx.setLineDash([5, 3]);
                                 ctx.lineWidth = 2;
                                 ctx.strokeStyle = "#07C";
                                 ctx.stroke();
                                 ctx.restore();
                                 }
                                 })
                                 }'
```